### PR TITLE
(WIP) Recovery

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,7 +16,7 @@
   "indent": 4,
   "maxparams": 5,
   "maxdepth": 3,
-  "maxlen": 160,
+  "maxlen": 256,
   "node": true,
   "esnext": true
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ eliq.getFromTo (<startdate>, <enddate>, '6min' | 'hour' | 'day').then(console.lo
 }
 ```
 
-## Recover
+## Recover (Experimental)
 In case ELIQ API is unresponsive (ie. response code 503), this options enable recovery
 of failed requests to the ELIQ API. Each failed request is persisted on file and being
 re-executed when calling ``eliq.recover(...)``.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ eliq.getFromTo (<startdate>, <enddate>, '6min' | 'hour' | 'day').then(console.lo
 ```
 
 ## Recover
+Just in case ELIQ API is unresponsive for some reason, this options enable recovery
+of failed requests to the ELIQ API. Each failed request is persisted on file and being
+re-executed when calling ``eliq.revover(...)``.
+
 ```Javascript
 var eliq = require('eliq-promise')({recover: true});
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm install eliq-promise
 ```Javascript
 var config = {
   eliqAccesstoken: '...',
+  recover: true|false
 },
 eliq = require('eliq-promise')(config);
 ```
@@ -61,6 +62,15 @@ eliq.getFromTo (<startdate>, <enddate>, '6min' | 'hour' | 'day').then(console.lo
     ...
    ]
 }
+```
+
+## Recover
+```Javascript
+var eliq = require('eliq-promise')({recover: true});
+```
+
+```Javascript
+eliq.recover(console);
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ npm install eliq-promise
 ```Javascript
 var config = {
   eliqAccesstoken: '...',
-  recover: true|false
+  recover: true|false (false),
+  recoveryFile: '/tmp/recovery.eliq'
 },
 eliq = require('eliq-promise')(config);
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ eliq.getFromTo (<startdate>, <enddate>, '6min' | 'hour' | 'day').then(console.lo
 ## Recover
 In case ELIQ API is unresponsive (ie. response code 503), this options enable recovery
 of failed requests to the ELIQ API. Each failed request is persisted on file and being
-re-executed when calling ``eliq.revover(...)``.
+re-executed when calling ``eliq.recover(...)``.
 
 ```Javascript
 var eliq = require('eliq-promise')({recover: true});

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ eliq.getFromTo (<startdate>, <enddate>, '6min' | 'hour' | 'day').then(console.lo
 ```
 
 ## Recover
-Just in case ELIQ API is unresponsive for some reason, this options enable recovery
+In case ELIQ API is unresponsive (ie. response code 503), this options enable recovery
 of failed requests to the ELIQ API. Each failed request is persisted on file and being
 re-executed when calling ``eliq.revover(...)``.
 
@@ -74,7 +74,7 @@ var eliq = require('eliq-promise')({recover: true});
 ```
 
 ```Javascript
-eliq.recover(console);
+eliq.recover(console.log);
 ```
 
 ## Notes

--- a/lib/eliq.js
+++ b/lib/eliq.js
@@ -4,7 +4,12 @@ var RSVP = require('rsvp'),
 
 module.exports = function (config) {
     'use strict';
-    var eliqUrl = require('./eliqurl')(config);
+    var eliqUrl = require('./eliqurl')(config),
+        recover = config.recover || require('./recover')({});
+
+    function restore (logger) {
+        return recover.restore(fetchData, logger.log);
+    }
 
     function fetchData (url) {
         return new RSVP.Promise(function (resolve, reject) {
@@ -16,15 +21,19 @@ module.exports = function (config) {
             request(options, function (error, response, body) {
                 if (!error && response && (response.statusCode === 200 || response.statusCode === 201)) {
                     resolve(body);
-                } else {
-                    error = error || 'Got status code ' + response.statusCode + ' for ' + options.url;
+                } else if (response.code >= 500 && response.code <= 599) {
+                    recover.log(url);
+                    reject(new Error('Got status code ' + response.statusCode + ' for ' + options.url));
+                } else if (error) {
                     reject(error);
+                } else {
+                    reject(new Error('Got status code ' + response.statusCode + ' for ' + options.url));
                 }
             });
         });
     }
 
-    function getNow() {
+    function getNow () {
         return fetchData(eliqUrl.now());
     }
 
@@ -40,6 +49,7 @@ module.exports = function (config) {
     return {
         getNow: getNow,
         getFrom: getFrom,
-        getFromTo: getFromTo
+        getFromTo: getFromTo,
+        restore: restore
     };
 };

--- a/lib/eliq.js
+++ b/lib/eliq.js
@@ -5,7 +5,7 @@ var RSVP = require('rsvp'),
 module.exports = function (config) {
     'use strict';
     var eliqUrl = require('./eliqurl')(config),
-        recover = config.recover || require('./recover')({});
+        recover = require('./recover')(config);
 
     function restore (log) {
         return recover.restore(fetchData, log);

--- a/lib/eliq.js
+++ b/lib/eliq.js
@@ -7,8 +7,8 @@ module.exports = function (config) {
     var eliqUrl = require('./eliqurl')(config),
         recover = config.recover || require('./recover')({});
 
-    function restore (logger) {
-        return recover.restore(fetchData, logger.log);
+    function restore (log) {
+        return recover.restore(fetchData, log);
     }
 
     function fetchData (url) {

--- a/lib/recover.js
+++ b/lib/recover.js
@@ -38,6 +38,12 @@ module.exports = function (config) {
         });
     }
 
+    /**
+     * Logs url to file. Note that duplicate urls will not be logged.
+     *
+     * @param url ELIQ API url
+     * @returns {RSVP.Promise}
+     */
     function log (url) {
         return _exists(url).then(function (exists) {
             if (!exists) {
@@ -50,11 +56,12 @@ module.exports = function (config) {
     /**
      * restore renames the recovery file, fetches each url, and logs the result.
      *
-     * @param fetch Function that "fetches" the url
-     * @param log Function that "logs" the result
+     * @param fetch Function that "fetches" the url and return a Promise
+     * @param log Function that "logs" the result and return a Promise
      * @returns {RSVP.Promise}
      */
     function restore (fetch, log) {
+        return RSVP.defer().resolve();
         return new RSVP.Promise(function (resolve, reject) {
             if (!fs.existsSync(file)) {
                 return resolve();

--- a/lib/recover.js
+++ b/lib/recover.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
     readline = require('readline'),
-    Transform = require('stream').Transform,
     RSVP = require('rsvp');
 
 module.exports = function (config) {

--- a/lib/recover.js
+++ b/lib/recover.js
@@ -33,14 +33,13 @@ module.exports = function (config) {
             rl.on('line', function (line) {
                 if (line.indexOf(url) >= 0) {
                     resolve(true);
-                    rs.close();
                 }
             });
         });
     }
 
     function log (url) {
-        _exists(url).then(function (exists) {
+        return _exists(url).then(function (exists) {
             if (!exists) {
                 return _append(url);
             }
@@ -75,7 +74,7 @@ module.exports = function (config) {
                     if (err) {
                         reject(err);
                     }
-                    console.log('successfully deleted' + tempFile);
+                    resolve();
                 });
             });
 

--- a/lib/recover.js
+++ b/lib/recover.js
@@ -1,0 +1,93 @@
+var fs = require('fs'),
+    readline = require('readline'),
+    Transform = require('stream').Transform,
+    RSVP = require('rsvp');
+
+module.exports = function (config) {
+    var file = config.recoveryFile || '/tmp/recovery.eliq';
+
+    function _append (url) {
+        return new RSVP.Promise(function (resolve, reject) {
+            fs.appendFile(file, url + '\n', function (err) {
+                if (err) {
+                    reject(err);
+                }
+                resolve();
+            });
+        });
+    }
+
+    function _exists (url) {
+        return new RSVP.Promise(function (resolve, reject) {
+            var rs = fs.createReadStream(file),
+                rl = readline.createInterface({
+                    input: rs,
+                    output: process.stdout
+                });
+
+            rs.on('error', function (err) {
+                reject(err);
+            }).on('end', function () {
+                resolve(false);
+            });
+
+            rl.on('line', function (line) {
+                if (line.indexOf(url) >= 0) {
+                    resolve(true);
+                    rs.close();
+                }
+            });
+        });
+    }
+
+    function log (url) {
+        _exists(url).then(function (exists) {
+            if (!exists) {
+                return _append(url);
+            }
+            return RSVP.defer().resolve();
+        });
+    }
+
+    /**
+     * restore renames the recovery file, fetches each url, and logs the result.
+     *
+     * @param fetch Function that "fetches" the url
+     * @param log Function that "logs" the result
+     * @returns {RSVP.Promise}
+     */
+    function restore (fetch, log) {
+        return new RSVP.Promise(function (resolve, reject) {
+            if (!fs.existsSync(file)) {
+                return resolve();
+            }
+            var tempFile = file + 'tmp';
+            fs.renameSync(file, tempFile);
+            var rs = fs.createReadStream(tempFile),
+                rl = readline.createInterface({
+                    input: rs,
+                    output: process.stdout
+                });
+
+            rs.on('error', function (err) {
+                reject(err);
+            }).on('end', function () {
+                fs.unlink(tempFile, function (err) {
+                    if (err) {
+                        reject(err);
+                    }
+                    console.log('successfully deleted' + tempFile);
+                });
+            });
+
+            rl.on('line', function (url) {
+                fetch(url).then(log).catch(reject);
+            });
+        });
+    }
+
+    return {
+        log: log,
+        restore: restore
+    };
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gulp-coverage": "^0.3.34",
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
+    "lodash": "^3.5.0",
     "mocha": "^2.1.0",
     "nock": "^1.1.0",
     "sinon": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/ashpool/eliq-promise",
   "devDependencies": {
     "chai": "^2.1.0",
+    "chai-as-promised": "^4.3.0",
     "gulp": "^3.8.11",
     "gulp-coverage": "^0.3.34",
     "gulp-jshint": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "gulp-coverage": "^0.3.34",
     "gulp-jshint": "^1.9.2",
     "gulp-mocha": "^2.0.0",
-    "mocha": "^2.1.0"
+    "mocha": "^2.1.0",
+    "nock": "^1.1.0",
+    "sinon": "^1.13.0"
   },
   "dependencies": {
     "moment-timezone": "^0.3.0",

--- a/test/eliq.js
+++ b/test/eliq.js
@@ -55,7 +55,7 @@ describe('eliq', function () {
                     .get('/api/data?accesstoken=fake&startdate=2015-03-02T20:00:00.000Z&enddate=2015-03-02T23:00:00.000Z&intervaltype=6min')
                     .reply(503, {});
                 var eliq = require('../lib/eliq')({eliqAccesstoken: 'fake'});
-                eliq.getFromTo(new Date('2015-03-02T20:00:00+00:00'), new Date('2015-03-02T23:00:00+00:00'), '6min').then(function (result) {
+                eliq.getFromTo(new Date('2015-03-02T20:00:00+00:00'), new Date('2015-03-02T23:00:00+00:00'), '6min').then(function () {
                     done('we should never get here');
                 }).catch(function (reason) {
                     expect(reason).to.be.an.instanceof(Error);

--- a/test/eliq.js
+++ b/test/eliq.js
@@ -1,0 +1,70 @@
+/*jshint undef:false */
+var nock = require('nock'),
+    chai = require('chai'),
+    expect = chai.expect;
+
+describe('eliq', function () {
+    describe('#getNow', function () {
+        it('fetches createddate and power', function (done) {
+            var scope = nock('https://my.eliq.se')
+                .get('/api/datanow?accesstoken=fake')
+                .reply(200, {createddate: '2015-03-10T05:38:20', power: 1285});
+            var eliq = require('../lib/eliq')({eliqAccesstoken: 'fake'});
+            eliq.getNow().then(function (result) {
+                expect(result.createddate).to.equal('2015-03-10T05:38:20');
+                expect(result.power).to.equal(1285);
+                scope.done();
+                done();
+            }).catch(function (reason) {
+                done(reason);
+            }).finally(function () {
+                nock.cleanAll();
+            });
+        });
+        describe('#getFromTo', function () {
+            it('fetches avgpower and energy', function (done) {
+                var scope = nock('https://my.eliq.se')
+                    .get('/api/data?accesstoken=fake&startdate=2015-03-02T20:00:00.000Z&enddate=2015-03-02T23:00:00.000Z&intervaltype=6min')
+                    .reply(200, {
+                        startdate: '2015-03-02T20:00:00+00:00',
+                        enddate: '2015-03-02T23:00:00+00:00',
+                        intervaltype: '6min',
+                        data: [{
+                            avgpower: 2790,
+                            energy: 279,
+                            temp_out: null,
+                            time_start: '2015-03-02T20:00:00',
+                            time_end: '2015-03-02T20:06:00'
+                        }]
+                    });
+                var eliq = require('../lib/eliq')({eliqAccesstoken: 'fake'});
+                eliq.getFromTo(new Date('2015-03-02T20:00:00+00:00'), new Date('2015-03-02T23:00:00+00:00'), '6min').then(function (result) {
+                    expect(result.startdate).to.equal('2015-03-02T20:00:00+00:00');
+                    expect(result.enddate).to.equal('2015-03-02T23:00:00+00:00');
+                    expect(result.intervaltype).to.equal('6min');
+                    scope.done();
+                    done();
+                }).catch(function (reason) {
+                    done(reason);
+                }).finally(function () {
+                    nock.cleanAll();
+                });
+            });
+            it('throws an error when server is down', function (done) {
+                var scope = nock('https://my.eliq.se')
+                    .get('/api/data?accesstoken=fake&startdate=2015-03-02T20:00:00.000Z&enddate=2015-03-02T23:00:00.000Z&intervaltype=6min')
+                    .reply(503, {});
+                var eliq = require('../lib/eliq')({eliqAccesstoken: 'fake'});
+                eliq.getFromTo(new Date('2015-03-02T20:00:00+00:00'), new Date('2015-03-02T23:00:00+00:00'), '6min').then(function (result) {
+                    done('we should never get here');
+                }).catch(function (reason) {
+                    expect(reason).to.be.an.instanceof(Error);
+                    scope.done();
+                    done();
+                }).finally(function () {
+                    nock.cleanAll();
+                });
+            });
+        });
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,4 @@
-require('./eliqurl');
 require('./date');
+require('./eliq');
+require('./eliqurl');
+require('./recover');

--- a/test/recover.js
+++ b/test/recover.js
@@ -1,16 +1,21 @@
 /*jshint undef:false */
 /*jshint unused:false */
-var nock = require('nock'),
+var fs  = require("fs"),
+    nock = require('nock'),
     chai = require('chai'),
     expect = chai.expect;
 
 describe('recover', function () {
-    var recover = require('../lib/recover')({file: '/tmp/eliq.recover'});
+    var file = '/tmp/test-eliq.recover',
+        recover = require('../lib/recover')({file: file});
     describe('#log', function () {
-        it('writes url to file', function(done) {
-            var url = 'https://fuu.bar.com';
-            recover.log(url);
+        it('writes url to file', function (done) {
+            fs.closeSync(fs.openSync(file, 'w'));
+            var array = fs.readFileSync(file).toString();
+            expect(array).to.equal('');
 
+            //var url = 'https://fuu.bar.com';
+            //recover.log(url);
 
 
             done();

--- a/test/recover.js
+++ b/test/recover.js
@@ -1,4 +1,5 @@
 /*jshint undef:false */
+/*jshint unused:false */
 var nock = require('nock'),
     chai = require('chai'),
     expect = chai.expect;
@@ -7,7 +8,7 @@ describe('recover', function () {
     var recover = require('../lib/recover')({file: '/tmp/eliq.recover'});
     describe('#log', function () {
         it('writes url to file', function(done) {
-            var url = "https://fuu.bar.com";
+            var url = 'https://fuu.bar.com';
             recover.log(url);
 
 

--- a/test/recover.js
+++ b/test/recover.js
@@ -1,0 +1,18 @@
+/*jshint undef:false */
+var nock = require('nock'),
+    chai = require('chai'),
+    expect = chai.expect;
+
+describe('recover', function () {
+    var recover = require('../lib/recover')({file: '/tmp/eliq.recover'});
+    describe('#log', function () {
+        it('writes url to file', function(done) {
+            var url = "https://fuu.bar.com";
+            recover.log(url);
+
+
+
+            done();
+        });
+    });
+});

--- a/test/recover.js
+++ b/test/recover.js
@@ -1,24 +1,70 @@
 /*jshint undef:false */
 /*jshint unused:false */
-var fs  = require("fs"),
+var fs = require('fs'),
+    _ = require('lodash'),
+    RSVP = require('rsvp'),
     nock = require('nock'),
     chai = require('chai'),
     expect = chai.expect;
 
+
+function file2Array (file) {
+    return _.compact(fs.readFileSync(file).toString().split('\n'));
+}
+
 describe('recover', function () {
     var file = '/tmp/test-eliq.recover',
-        recover = require('../lib/recover')({file: file});
+        recover = require('../lib/recover')({recoveryFile: file});
+
     describe('#log', function () {
-        it('writes url to file', function (done) {
+        var url = 'https://fuu.bar.com';
+
+        beforeEach(function () {
             fs.closeSync(fs.openSync(file, 'w'));
-            var array = fs.readFileSync(file).toString();
-            expect(array).to.equal('');
+        });
 
-            //var url = 'https://fuu.bar.com';
-            //recover.log(url);
+        afterEach(function (done) {
+            fs.unlink(file, function (err) {
+                if (err) {
+                    throw err;
+                }
+                done();
+            });
+        });
 
-
-            done();
+        it('writes url to file', function (done) {
+            recover.log(url).then(function () {
+                var array = file2Array(file);
+                expect(array.length).to.equal(1);
+                expect(array[0]).to.equal(url);
+                done();
+            }).catch(function (reason) {
+                done(reason);
+            });
+        });
+        it('writes urls to file', function (done) {
+            RSVP.allSettled([url + 'a', url + 'b', url + 'c', url + 'd'].map(recover.log)).then(function () {
+                var array = file2Array(file);
+                expect(array.length).to.equal(4);
+                expect(array).to.contain(url + 'a');
+                done();
+            }).catch(function (reason) {
+                done(reason);
+            });
+        });
+        it('writes url to file only once', function (done) {
+            recover.log(url).then(function () {
+                recover.log(url).then(function () {
+                    var array = file2Array(file);
+                    expect(array.length).to.equal(1);
+                    expect(array[0]).to.equal(url);
+                    done();
+                }).catch(function (reason) {
+                    done(reason);
+                });
+            }).catch(function (reason) {
+                done(reason);
+            });
         });
     });
 });

--- a/test/recover.js
+++ b/test/recover.js
@@ -5,8 +5,10 @@ var fs = require('fs'),
     RSVP = require('rsvp'),
     nock = require('nock'),
     chai = require('chai'),
+    chaiAsPromised = require('chai-as-promised'),
     expect = chai.expect;
 
+chai.use(chaiAsPromised);
 
 function file2Array (file) {
     return _.compact(fs.readFileSync(file).toString().split('\n'));
@@ -14,24 +16,27 @@ function file2Array (file) {
 
 describe('recover', function () {
     var file = '/tmp/test-eliq.recover',
-        recover = require('../lib/recover')({recoveryFile: file});
+        recover = require('../lib/recover')({recoveryFile: file}),
+        url = 'https://fuu.bar.com';
+
+    beforeEach(function () {
+        fs.closeSync(fs.openSync(file, 'w'));
+    });
+
+    afterEach(function (done) {
+        if (!fs.existsSync(file)) {
+            done();
+            return;
+        }
+        fs.unlink(file, function (err) {
+            if (err) {
+                done(err);
+            }
+            done();
+        });
+    });
 
     describe('#log', function () {
-        var url = 'https://fuu.bar.com';
-
-        beforeEach(function () {
-            fs.closeSync(fs.openSync(file, 'w'));
-        });
-
-        afterEach(function (done) {
-            fs.unlink(file, function (err) {
-                if (err) {
-                    throw err;
-                }
-                done();
-            });
-        });
-
         it('writes url to file', function (done) {
             recover.log(url).then(function () {
                 var array = file2Array(file);
@@ -64,6 +69,47 @@ describe('recover', function () {
                 });
             }).catch(function (reason) {
                 done(reason);
+            });
+        });
+    });
+
+    describe('#restore', function () {
+        it('returns happily if there is no log', function (done) {
+            function fetch () {
+            }
+
+            function log () {
+            }
+
+            require('../lib/recover')({recoveryFile: './nonexistingfile'}).restore(fetch, log).then(function () {
+                done();
+            }).catch(function (reason) {
+                done(reason);
+            });
+        });
+        it('calls fetch and log', function (done) {
+            var fetchCalled = false,
+                logCalled = false;
+
+            function fetch () {
+                return new RSVP.Promise(function (resolve) {
+                    fetchCalled = true;
+                    resolve();
+                });
+            }
+
+            function log () {
+                return new RSVP.Promise(function (resolve) {
+                    logCalled = true;
+                    resolve();
+                });
+            }
+
+            recover.log(url).then(function () {
+                recover.restore(fetch, log).should.be.fulfilled().notify(done);
+                console.log('FUUUU');
+/*                fetch.should.be.fulfilled();
+                log.should.be.fulfilled();*/
             });
         });
     });


### PR DESCRIPTION
# What

Uptime is sometimes terrible for the ELIQ API. And sometimes data is late. This is a first attempt on recovery of failed requests to ELIQ API.

No data:

```
{ startdate: '2015-03-18T14:00:00+00:00',
  enddate: '2015-03-18T15:00:00+00:00',
  intervaltype: '6min',
  data: [] }
```

The logic goes something like this:
- Log failed requests to file (do not store duplicates)
- Call `recover` function that will read stored attempts and replay them (GOTO 1 if fail)
- There should probably be some a limit on age or retries
